### PR TITLE
Updates to get whisper building on Rust 1.13

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(test, path_ext, dir_builder)]
+#![feature(test)]
 
 extern crate memmap;
 extern crate byteorder;

--- a/src/whisper/cache/mod.rs
+++ b/src/whisper/cache/mod.rs
@@ -1,9 +1,8 @@
 // use carbon::CarbonMsg;
 // use whisper::{ WhisperFile, MutexWhisperFile };
 use whisper::{ WhisperFile, Schema };
-use std::collections::HashMap;
 use std::path::{ Path, PathBuf };
-use std::fs::{ PathExt, DirBuilder };
+use std::fs::DirBuilder;
 use std::io;
 use std::sync::{ Arc, Mutex };
 use lru_cache::LruCache;
@@ -88,9 +87,9 @@ mod test {
 	extern crate test;
 	use test::Bencher;
 
-	use std::path::{ Path };
+	use std::path::Path;
 
-	use whisper::{ WhisperCache, NamedPoint, Schema, Point };
+	use whisper::{ WhisperCache, NamedPoint, Schema };
 
 	#[bench]
 	fn test_opening_new_whisper_file(b: &mut Bencher){

--- a/src/whisper/cache/named_point.rs
+++ b/src/whisper/cache/named_point.rs
@@ -23,7 +23,7 @@ impl NamedPoint {
             Err(_) => return Err( "invalid utf8 character".to_string() )
         };
 
-        let parsed_lines : Vec<Result<NamedPoint,String>> = datagram.lines_any().map(|x| NamedPoint::parse_line(x) ).collect();
+        let parsed_lines : Vec<Result<NamedPoint,String>> = datagram.lines().map(|x| NamedPoint::parse_line(x) ).collect();
         if parsed_lines.iter().any(|x| x.is_err() ) {
         	Err("datagram had invalid entries. skipping all.".to_string())
         } else {
@@ -88,7 +88,6 @@ mod tests {
 
     use whisper::Point;
     use super::*;
-    use std::path::Path;
 
     #[bench]
     fn bench_good_datagram_line(b: &mut Bencher){

--- a/src/whisper/file/archive.rs
+++ b/src/whisper/file/archive.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::cmp;
 
 use memmap::MmapViewSync;
 use byteorder::{ByteOrder, BigEndian };
@@ -38,7 +37,6 @@ impl Archive {
 			points: points,
 			mmap_view: mmap_view
 		}
-		
 	}
 
 	pub fn write(&mut self, point: &Point ) {
@@ -57,7 +55,7 @@ impl Archive {
 		assert!(self.points() >= points.len(), "did not hold: {} >= {}", self.points(), points.len());
 		let start = self.archive_index(&from);
 
-		let mut data_needed = points.len()*point::POINT_SIZE as usize;
+		let data_needed = points.len()*point::POINT_SIZE as usize;
 
 		let end_of_read = (start.0 as usize)*point::POINT_SIZE + data_needed;
 
@@ -243,7 +241,7 @@ mod tests {
 
 	#[test]
 	fn test_read(){
-		let mut anon_view = build_mmap().into_view_sync();
+		let anon_view = build_mmap().into_view_sync();
 		let mut archive = Archive::new(2, 3, anon_view);
 		assert_eq!(archive.anchor_bucket_name(), BucketName(1440392088) );
 		assert_eq!(archive.seconds_per_point(), 2);
@@ -254,7 +252,7 @@ mod tests {
 		{
 			let mut points_buf = Vec::with_capacity(3);
 			unsafe{ points_buf.set_len(3) };
-			archive.read_points(BucketName(0), &mut points_buf[..]);		
+			archive.read_points(BucketName(0), &mut points_buf[..]);
 			let expected = vec![
 				Point(1440392088, 100.0),
 				Point(1440392090, 100.0),
@@ -268,7 +266,7 @@ mod tests {
 			assert_eq!(archive.archive_index(&bucket_name).0, 1);
 
 			unsafe{ points_buf.set_len(1) };
-			archive.read_points(bucket_name, &mut points_buf[..]);		
+			archive.read_points(bucket_name, &mut points_buf[..]);
 			assert_eq!(points_buf[0].0, 1440392090);
 			assert_eq!(points_buf[0].1, 8.0);
 		}

--- a/src/whisper/file/header.rs
+++ b/src/whisper/file/header.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use memmap::MmapViewSync;
-use byteorder::{ ByteOrder, BigEndian, ReadBytesExt };
+use byteorder::{ ByteOrder, BigEndian };
 
 use super::archive::{ self, Archive };
 use super::super::point;
@@ -60,7 +60,7 @@ impl Header {
 
 		Header::new(agg_type, max_retention, x_files_factor)
 	}
-	
+
 	pub fn new(agg_type: AggregationType, max_ret: u32, xff: f32) -> Header {
 		Header {
 			aggregation_type: agg_type,

--- a/src/whisper/file/mod.rs
+++ b/src/whisper/file/mod.rs
@@ -1,5 +1,5 @@
 use memmap::{ Mmap, Protection };
-use byteorder::{ ByteOrder, BigEndian, WriteBytesExt };
+use byteorder::{ BigEndian, WriteBytesExt };
 
 mod header;
 pub mod archive;
@@ -16,7 +16,7 @@ use whisper::Schema;
 // Modules needed to create file on disk
 use std::fs::OpenOptions;
 extern crate libc;
-use self::libc::funcs::posix01::unistd::ftruncate;
+use self::libc::ftruncate;
 use std::os::unix::prelude::AsRawFd;
 use std::io::{ self, Error};
 use std::path::{ Path, PathBuf };
@@ -148,7 +148,7 @@ mod tests {
 	use whisper::{ Schema, WhisperFile, Point };
 	use super::header;
 
-	use std::path::{ Path, PathBuf};
+	use std::path::Path;
 	use std::io::Cursor;
 	use std::io::Write;
 	use memmap::{ Mmap, Protection };

--- a/src/whisper/point.rs
+++ b/src/whisper/point.rs
@@ -1,8 +1,8 @@
 use super::file::archive::BucketName;
 
-use std::io::{ Write, Cursor };
+use std::io::Cursor;
 
-use byteorder::{ByteOrder, BigEndian, WriteBytesExt };
+use byteorder::{ ByteOrder, BigEndian, WriteBytesExt };
 
 pub const POINT_SIZE : usize = 12;
 

--- a/src/whisper/schema/retention_policy.rs
+++ b/src/whisper/schema/retention_policy.rs
@@ -1,7 +1,7 @@
 use whisper::point::POINT_SIZE;
 use whisper::file::archive::ARCHIVE_INFO_SIZE;
 
-use byteorder::{ ByteOrder, BigEndian, WriteBytesExt };
+use byteorder::{ BigEndian, WriteBytesExt };
 use regex;
 
 use std::io::{ BufWriter, Write };
@@ -153,7 +153,7 @@ mod tests {
             precision: 1 *  60*60*24,
             retention: 60 * 60*60*24*365
         };
-        
+
         let retention_opt = RetentionPolicy::spec_to_retention_policy(spec);
         assert!(retention_opt.is_some());
         let retention_policy = retention_opt.unwrap();


### PR DESCRIPTION
- Removed feature flags no longer needed
- Changed use statement for libc function
- Remove use of PathExt trait (part of Path now)
- Assorted compiler warning cleanups

Fixes #1
