### PR TITLE
Remove unused function, acknowledge and allow unused variable pending…

### DIFF
--- a/src/bin/whisper.rs
+++ b/src/bin/whisper.rs
@@ -89,6 +89,7 @@ fn cmd_dump(path: &Path) {
     println!("{:?}", whisper_file);
 }
 
+#[allow(unused_variables)] /*TODO: Remove once we reenable writing current_time*/
 fn cmd_update(args: Args, path: &Path, current_time: u64) {
     let mut file = WhisperFile::open(path);
     let point = Point(args.arg_timestamp.parse::<u32>().unwrap(),

--- a/src/whisper/file/archive.rs
+++ b/src/whisper/file/archive.rs
@@ -111,14 +111,8 @@ impl Archive {
 		self.mmap_view.len()
 	}
 
-	#[inline]
-    fn bucket_name(&self, timestamp: u32) -> BucketName {
-        let bucket_name = timestamp - (timestamp % self.seconds_per_point);
-        BucketName(bucket_name)
-    }
-
     #[inline]
-    fn bucket(&self, timestamp: u32) -> BucketName {
+    fn bucket_name(&self, timestamp: u32) -> BucketName {
         let bucket_name = timestamp - (timestamp % self.seconds_per_point);
         BucketName(bucket_name)
     }


### PR DESCRIPTION
✂️  the the unused `bucket` function. Looks like `bucket` was the original source for `bucket_name`, but lingered around. 
Also squelched a warning already covered with a `TODO`