### PR TITLE
Make all test code conditional on test configuration, clean up test warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
-#![feature(test)]
+#![cfg_attr(test, feature(test))]
 
 extern crate memmap;
 extern crate byteorder;
 extern crate regex;
 extern crate libc;
-extern crate test;
+#[cfg(test)] extern crate test;
 extern crate lru_cache;
 
 #[macro_use]

--- a/src/whisper/cache/mod.rs
+++ b/src/whisper/cache/mod.rs
@@ -100,7 +100,7 @@ mod test {
 		let current_time = 1434598525;
 
 		b.iter(move ||{
-			let metric = NamedPoint::new("hey.there.bear".to_string(), 1434598525, 0.0);
+			let metric = NamedPoint::new("hey.there.bear".to_string(), current_time, 0.0);
 			cache.write(metric).unwrap();
 		});
 	}

--- a/src/whisper/file/archive.rs
+++ b/src/whisper/file/archive.rs
@@ -219,9 +219,9 @@ mod tests {
 		let archive = Archive::new(2, 3, anon_view);
 
 		// Our bucket names are aligned, ts normalization is working
-		assert_eq!(archive.bucket(1440392088).0, 1440392088);
-		assert_eq!(archive.bucket(1440392090).0, 1440392090);
-		assert_eq!(archive.bucket(1440392092).0, 1440392092);
+		assert_eq!(archive.bucket_name(1440392088).0, 1440392088);
+		assert_eq!(archive.bucket_name(1440392090).0, 1440392090);
+		assert_eq!(archive.bucket_name(1440392092).0, 1440392092);
 
 		// Assert absolute index in to archive
 		assert_eq!(archive.archive_index(&BucketName(1440392088)).0, 0);


### PR DESCRIPTION
This crate was using `#![feature(test)]`, which is not allowed on stable. Updated the feature attribute and the `test` crate to conditionally compile only when testing, allowing us to build on stable.

Also changed `bucket` fn calls to `bucket_name`, and used the `current_time` variable instead of the literal.