### PR TITLE
Change everywhere we take &paths to instead take AsRef<Path>, to improve ergonomics for consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ How do I use it?
 Simply opening a whisper file:
 
 ```
-let path = Path::new("/tmp/blah.wsp").to_path_buf();
+let path = "/tmp/blah.wsp";
 let default_specs = vec!["1s:60s".to_string(), "1m:1y".to_string()];
 let schema = Schema::new_from_retention_specs(default_specs);
 
-let file = WhisperFile::new(&path, schema).unwrap();
+let file = WhisperFile::new(path, schema).unwrap();
 // do things with the file
 ```

--- a/src/bin/whisper.rs
+++ b/src/bin/whisper.rs
@@ -53,11 +53,9 @@ pub fn main(){
                             .unwrap_or_else(|e| e.exit());
 
     let arg_file = args.arg_file.clone();
-    let path_str : &str = unsafe {
+    let path: &str = unsafe {
         arg_file.slice_unchecked(0, args.arg_file.len())
     };
-    let path = Path::new(path_str);
-
 
     let current_time = time::get_time().sec as u64;
 
@@ -78,18 +76,22 @@ pub fn main(){
     }
 }
 
-fn cmd_info(path: &Path) {
+fn cmd_info<P>(path: P)
+  where P: AsRef<Path> {
     let whisper_file = WhisperFile::open(path);
     // TODO: used to simpler of Display, not Debug
     println!("{:?}", whisper_file);
 }
 
-fn cmd_dump(path: &Path) {
+fn cmd_dump<P>(path: P)
+  where P: AsRef<Path> {
     let whisper_file = WhisperFile::open(path);
     println!("{:?}", whisper_file);
 }
 
-fn cmd_update(args: Args, path: &Path, current_time: u64) {
+#[allow(unused_variables)] /*TODO: Remove once we reenable writing current_time*/
+fn cmd_update<P>(args: Args, path: P, current_time: u64)
+  where P: AsRef<Path> {
     let mut file = WhisperFile::open(path);
     let point = Point(args.arg_timestamp.parse::<u32>().unwrap(),
         					args.arg_value.parse::<f64>().unwrap());
@@ -98,14 +100,16 @@ fn cmd_update(args: Args, path: &Path, current_time: u64) {
     file.write(/*current_time, TODO: reenable */ &point);
 }
 
-fn cmd_mark(args: Args, path: &Path, current_time: u64) {
+fn cmd_mark<P>(args: Args, path: P, current_time: u64)
+  where P: AsRef<Path> {
     let mut file = WhisperFile::open(path);
     let point = Point(current_time as u32, args.arg_value.parse::<f64>().unwrap());
 
     file.write(/*current_time, TODO: reenable */ &point);
 }
 
-fn cmd_thrash(args: Args, path: &Path, current_time: u64) {
+fn cmd_thrash<P>(args: Args, path: P, current_time: u64)
+  where P: AsRef<Path> {
     let times = args.arg_times.parse::<u32>().unwrap();
     let mut file = WhisperFile::open(path);
     for index in 1..times {
@@ -116,7 +120,8 @@ fn cmd_thrash(args: Args, path: &Path, current_time: u64) {
     }
 }
 
-fn cmd_create(args: Args, path: &Path) {
+fn cmd_create<P>(args: Args, path: P)
+  where P: AsRef<Path> {
     let schema = Schema::new_from_retention_specs(args.arg_timespec);
     let new_result = WhisperFile::new(path, &schema);
     match new_result {

--- a/src/whisper/cache/mod.rs
+++ b/src/whisper/cache/mod.rs
@@ -20,9 +20,10 @@ pub struct WhisperCache {
 }
 
 impl WhisperCache {
-	pub fn new(base_path: &Path, size: usize, schema: Schema) -> WhisperCache {
+	pub fn new<P>(base_path: P, size: usize, schema: Schema) -> WhisperCache
+        where P: AsRef<Path> {
 		WhisperCache {
-			base_path: base_path.to_path_buf(),
+			base_path: base_path.as_ref().to_path_buf(),
 			open_files: LruCache::new(size),
 			schema: schema
 		}
@@ -86,9 +87,6 @@ impl WhisperCache {
 mod test {
 	extern crate test;
 	use test::Bencher;
-
-	use std::path::Path;
-
 	use whisper::{ WhisperCache, NamedPoint, Schema };
 
 	#[bench]
@@ -96,7 +94,7 @@ mod test {
 		let default_specs = vec!["1s:60s".to_string(), "1m:1y".to_string()];
 		let schema = Schema::new_from_retention_specs(default_specs);
 
-		let mut cache = WhisperCache::new(&Path::new("/tmp"), 100, schema);
+		let mut cache = WhisperCache::new("/tmp", 100, schema);
 		let current_time = 1434598525;
 
 		b.iter(move ||{


### PR DESCRIPTION
Whenever we're asked to provide an `&Path`, it's much easier ergonomically to just provide the base `&'static str` rather than manually wrapping it. This updates WhisperFile to take `AsRef<Path>`s which includes `&str`, and cheaply convert to &Paths.