### PR TITLE
Replace calls to `exit` with `Result`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Simply opening a whisper file:
 ```
 let path = "/tmp/blah.wsp";
 let default_specs = vec!["1s:60s".to_string(), "1m:1y".to_string()];
-let schema = Schema::new_from_retention_specs(default_specs);
+let schema = Schema::new_from_retention_specs(default_specs).unwrap();
 
 let file = WhisperFile::new(path, schema).unwrap();
 // do things with the file

--- a/src/bin/whisper.rs
+++ b/src/bin/whisper.rs
@@ -122,7 +122,7 @@ fn cmd_thrash<P>(args: Args, path: P, current_time: u64)
 
 fn cmd_create<P>(args: Args, path: P)
   where P: AsRef<Path> {
-    let schema = Schema::new_from_retention_specs(args.arg_timespec);
+    let schema = Schema::new_from_retention_specs(args.arg_timespec).unwrap();
     let new_result = WhisperFile::new(path, &schema);
     match new_result {
     	// TODO change to Display

--- a/src/whisper/cache/mod.rs
+++ b/src/whisper/cache/mod.rs
@@ -92,7 +92,7 @@ mod test {
 	#[bench]
 	fn test_opening_new_whisper_file(b: &mut Bencher){
 		let default_specs = vec!["1s:60s".to_string(), "1m:1y".to_string()];
-		let schema = Schema::new_from_retention_specs(default_specs);
+		let schema = Schema::new_from_retention_specs(default_specs).unwrap();
 
 		let mut cache = WhisperCache::new("/tmp", 100, schema);
 		let current_time = 1434598525;

--- a/src/whisper/file/mod.rs
+++ b/src/whisper/file/mod.rs
@@ -209,7 +209,7 @@ mod tests {
 	fn test_write() {
 		let path = "/tmp/blah.wsp";
 		let default_specs = vec!["1s:60s".to_string(), "1m:1y".to_string()];
-		let schema = Schema::new_from_retention_specs(default_specs);
+		let schema = Schema::new_from_retention_specs(default_specs).unwrap();
 
 		let mut file = WhisperFile::new(path, &schema).unwrap();
 


### PR DESCRIPTION
I noticed Schema construction had multiple paths that may fail, and we were calling `exit` when we hit a failure case. Fulfilled the `TODO` to wrap the control flow in `Result`s instead. For expediency the results are simply `String`s in the error case, but in the future it should be straightforward to wrap them in a domain-appropriate error struct.