### PR TITLE
Implement downsampling on archive write

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open tasks
 
  - [x] `WhisperCache`
  - [ ] Validate `whisper-dump.py` behavior
- - [ ] Aggregations on write
+ - [x] Aggregations on write
  - [ ] `SchemaRegistry` or similar
  - [ ] Validate retention policies in schema
  - [ ] Validate WhisperFile when opening
@@ -63,6 +63,6 @@ let path = "/tmp/blah.wsp";
 let default_specs = vec!["1s:60s".to_string(), "1m:1y".to_string()];
 let schema = Schema::new_from_retention_specs(default_specs).unwrap();
 
-let file = WhisperFile::new(path, schema).unwrap();
+let file = WhisperFile::new(path, schema, AggregationType::Sum, 0.0).unwrap();
 // do things with the file
 ```

--- a/src/bin/whisper.rs
+++ b/src/bin/whisper.rs
@@ -8,7 +8,7 @@ extern crate time;
 extern crate whisper;
 
 use docopt::Docopt;
-use whisper::{ WhisperFile, Point, Schema };
+use whisper::{ WhisperFile, Point, Schema, AggregationType };
 
 use std::path::Path;
 
@@ -123,7 +123,7 @@ fn cmd_thrash<P>(args: Args, path: P, current_time: u64)
 fn cmd_create<P>(args: Args, path: P)
   where P: AsRef<Path> {
     let schema = Schema::new_from_retention_specs(args.arg_timespec).unwrap();
-    let new_result = WhisperFile::new(path, &schema);
+    let new_result = WhisperFile::new(path, &schema, AggregationType::Average, 0.5);
     match new_result {
     	// TODO change to Display
         Ok(whisper_file) => println!("Success! {:?}", whisper_file),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate regex;
 extern crate libc;
 #[cfg(test)] extern crate test;
 extern crate lru_cache;
+extern crate time;
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,4 @@ extern crate log;
 
 mod whisper;
 
-pub use self::whisper::{ WhisperFile, Point, Schema, WhisperCache, NamedPoint };
+pub use self::whisper::{ WhisperFile, AggregationType, Point, Schema, WhisperCache, NamedPoint };

--- a/src/whisper/cache/mod.rs
+++ b/src/whisper/cache/mod.rs
@@ -1,6 +1,6 @@
 // use carbon::CarbonMsg;
 // use whisper::{ WhisperFile, MutexWhisperFile };
-use whisper::{ WhisperFile, Schema };
+use whisper::{ WhisperFile, Schema, AggregationType };
 use std::path::{ Path, PathBuf };
 use std::fs::DirBuilder;
 use std::io;
@@ -71,7 +71,7 @@ impl WhisperCache {
 					try!( DirBuilder::new().recursive(true).create( path_on_disk.parent().unwrap() ) );
 				}
 				debug!("`{:?}` must now be created", path_on_disk);
-				try!( WhisperFile::new(&path_on_disk, &self.schema) )
+				try!( WhisperFile::new(&path_on_disk, &self.schema, AggregationType::Average, 0.5) )
 
 			};
 

--- a/src/whisper/file/archive.rs
+++ b/src/whisper/file/archive.rs
@@ -107,6 +107,11 @@ impl Archive {
     }
 
     #[inline]
+    pub fn retention(&self) -> usize {
+        self.seconds_per_point as usize * self.points
+    }
+
+    #[inline]
     pub fn size(&self) -> usize {
         self.mmap_view.len()
     }
@@ -125,21 +130,18 @@ impl Archive {
         if anchor_bucket_name.0 == 0 {
             ArchiveIndex(0)
         } else {
-            let time_distance = bucket_name.0 + anchor_bucket_name.0;
-            // let distance_in_points = time_distance / self.seconds_per_point;
-            // let point_distance = ( anchor_bucket_name.0 - bucket_name.0 ) % (self.points as u32);
-            let point_distance = time_distance / self.seconds_per_point;
-            // panic!("({}-{}) % {} = {}", anchor_bucket_name.0, bucket_name.0, self.points, point_distance);
-            let index = Archive::py_mod(point_distance, self.points as u32);
+            let time_distance = bucket_name.0 as i64 - anchor_bucket_name.0 as i64;
+            let point_distance = time_distance / self.seconds_per_point as i64;
+            let index = Archive::py_mod(point_distance, self.points as i64);
             ArchiveIndex(index)
         }
     }
 
-    fn py_mod(input: u32, base: u32) -> u32 {
-        let remainder = input as i64 % base as i64;
+    fn py_mod(input: i64, base: i64) -> u32 {
+        let remainder = input % base;
 
         if remainder < 0 {
-            (base as i64 + remainder) as u32
+            (base + remainder) as u32
         } else {
             (remainder) as u32
         }

--- a/src/whisper/file/archive.rs
+++ b/src/whisper/file/archive.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::io::{Result, Error, ErrorKind};
 
 use memmap::MmapViewSync;
 use byteorder::{ByteOrder, BigEndian };
@@ -18,10 +19,10 @@ pub struct ArchiveIndex(pub u32);
 pub struct BucketName(pub u32);
 
 pub struct Archive {
-	seconds_per_point: u32,
-	points: usize,
+    seconds_per_point: u32,
+    points: usize,
 
-	mmap_view: MmapViewSync
+    mmap_view: MmapViewSync
 }
 
 impl fmt::Debug for Archive {
@@ -31,85 +32,84 @@ impl fmt::Debug for Archive {
 }
 
 impl Archive {
-	pub fn new(seconds_per_point: u32, points: usize, mmap_view: MmapViewSync) -> Archive {
-		Archive {
-			seconds_per_point: seconds_per_point,
-			points: points,
-			mmap_view: mmap_view
-		}
-	}
+    pub fn new(seconds_per_point: u32, points: usize, mmap_view: MmapViewSync) -> Archive {
+        Archive {
+            seconds_per_point: seconds_per_point,
+            points: points,
+            mmap_view: mmap_view
+        }
+    }
 
-	pub fn write(&mut self, point: &Point ) {
-		let bucket_name = self.bucket_name(point.0);
+    pub fn write(&mut self, point: &Point) {
+        let bucket_name = self.bucket_name(point.0);
 
-		let archive_index = self.archive_index(&bucket_name);
+        let archive_index = self.archive_index(&bucket_name);
+        let start = archive_index.0 as usize * point::POINT_SIZE;
+        let end = archive_index.0 as usize * point::POINT_SIZE + point::POINT_SIZE;
 
-		let start = archive_index.0 as usize * point::POINT_SIZE;
-		let end = archive_index.0 as usize * point::POINT_SIZE + point::POINT_SIZE;
+        let mut point_slice = &mut self.mut_slice()[start .. end];
+        point.write_to_slice(bucket_name, point_slice);
+    }
 
-		let mut point_slice = &mut self.mut_slice()[start .. end];
-		point.write_to_slice(bucket_name, point_slice);
-	}
+    pub fn read_points(&self, from: BucketName, points: &mut[Point]) -> Result<()> {
+        if self.points() < points.len() {
+          return Err(Error::new(ErrorKind::InvalidInput, format!("Points requested exceeds archive retention period. Requested: {}, Available: {}", points.len(), self.points())));
+        }
 
-	pub fn read_points(&self, from: BucketName, points: &mut[Point]) {
-		assert!(self.points() >= points.len(), "did not hold: {} >= {}", self.points(), points.len());
-		let start = self.archive_index(&from);
+        let start = self.archive_index(&from);
+        let bytes_needed = points.len()*point::POINT_SIZE as usize;
+        let end_of_read = (start.0 as usize)*point::POINT_SIZE + bytes_needed;
 
-		let data_needed = points.len()*point::POINT_SIZE as usize;
+        // Wrap around reads need two different passes
+        if end_of_read > self.size() {
+            let overflow_bytes = end_of_read-self.size();
+            let first_start = start.0 as usize * point::POINT_SIZE;
+            let first_end = self.size();
+            let first_data = &self.slice()[first_start .. first_end];
 
-		let end_of_read = (start.0 as usize)*point::POINT_SIZE + data_needed;
+            let second_start = 0;
+            let second_end = overflow_bytes;
+            let second_data = &self.slice()[second_start .. second_end];
 
-		// Wrap around reads need two different passes
-		if end_of_read > self.size() {
-			let overflow_bytes = end_of_read-self.size();
+            let (first_buf, second_buf) = points.split_at_mut(first_data.chunks(point::POINT_SIZE).len());
+            Archive::write_data_as_points_to_slice(first_data, first_buf).and_then(|_| {
+              Archive::write_data_as_points_to_slice(second_data, second_buf)
+            })
+        } else {
+            let start_index = start.0 as usize * point::POINT_SIZE;
+            let end_index = end_of_read;
+            let points_data = &self.slice()[start_index .. end_index];
+            Archive::write_data_as_points_to_slice(points_data, points)
+        }
+    }
 
-			let mut index = 0;
-			let first_start = start.0 as usize * point::POINT_SIZE;
-			let first_end = self.size();
-			let first_data = &self.slice()[first_start .. first_end];
+    fn write_data_as_points_to_slice(data: &[u8], buf: &mut [Point]) -> Result<()> {
+        for (i, pt_data) in data.chunks(point::POINT_SIZE).enumerate() {
+            if pt_data.len() != point::POINT_SIZE {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Could not divide archive into points- got malformed point of size {}", pt_data.len())
+                ));
+            }
+            buf[i] = Point::new_from_slice(pt_data);
+        };
+        Ok(())
+    }
 
-			let second_start = 0;
-			let second_end = overflow_bytes;
-			let second_data = &self.slice()[second_start .. second_end];
+    #[inline]
+    pub fn seconds_per_point(&self) -> u32 {
+        self.seconds_per_point
+    }
 
-			for pt_data in first_data.chunks(point::POINT_SIZE) {
-				assert!(pt_data.len() >= 8, "pt_data.len(): {} < 8 (first_start: {}, first_end: {})", pt_data.len(), first_start, first_end);
-				points[index] = Point::new_from_slice(pt_data);
-				index = index + 1;
-			};
-			for pt_data in second_data.chunks(point::POINT_SIZE) {
-				assert!(pt_data.len() >= 8, "pt_data.len(): {} < 8", pt_data.len());
-				points[index] = Point::new_from_slice(pt_data);
-				index = index + 1;
-			};
-		} else {
-			let start_index = start.0 as usize * point::POINT_SIZE;
-			let end_index = end_of_read;
+    #[inline]
+    pub fn points(&self) -> usize {
+        self.points
+    }
 
-			let points_data = &self.slice()[start_index .. end_index];
-			for (i,pt_data) in points_data.chunks(point::POINT_SIZE).enumerate() {
-				assert!(pt_data.len() >= 8, "pt_data.len(): {} < 8", pt_data.len());
-				println!("pt_data: 0x{:x}{:x}{:x}{:x}", pt_data[0], pt_data[1], pt_data[2], pt_data[3]);
-				// TODO: should we instead pass the point in to the constructor?
-				points[i] = Point::new_from_slice(pt_data)
-			};
-		};
-	}
-
-	#[inline]
-	pub fn seconds_per_point(&self) -> u32 {
-		self.seconds_per_point
-	}
-
-	#[inline]
-	pub fn points(&self) -> usize {
-		self.points
-	}
-
-	#[inline]
-	pub fn size(&self) -> usize {
-		self.mmap_view.len()
-	}
+    #[inline]
+    pub fn size(&self) -> usize {
+        self.mmap_view.len()
+    }
 
     #[inline]
     fn bucket_name(&self, timestamp: u32) -> BucketName {
@@ -119,20 +119,20 @@ impl Archive {
 
     #[inline]
     fn archive_index(&self, bucket_name: &BucketName) -> ArchiveIndex {
-    	// This line unnecessarily keeps that first data page hot all the time.
-    	// TODO: cache
-    	let anchor_bucket_name = self.anchor_bucket_name();
-    	if anchor_bucket_name.0 == 0 {
-    		ArchiveIndex(0)
-    	} else {
-    		let time_distance = bucket_name.0 + anchor_bucket_name.0;
-    		// let distance_in_points = time_distance / self.seconds_per_point;
-    		// let point_distance = ( anchor_bucket_name.0 - bucket_name.0 ) % (self.points as u32);
-    		let point_distance = time_distance / self.seconds_per_point;
-    		// panic!("({}-{}) % {} = {}", anchor_bucket_name.0, bucket_name.0, self.points, point_distance);
-    		let index = Archive::py_mod(point_distance, self.points as u32);
-    		ArchiveIndex(index)
-    	}
+        // This line unnecessarily keeps that first data page hot all the time.
+        // TODO: cache
+        let anchor_bucket_name = self.anchor_bucket_name();
+        if anchor_bucket_name.0 == 0 {
+            ArchiveIndex(0)
+        } else {
+            let time_distance = bucket_name.0 + anchor_bucket_name.0;
+            // let distance_in_points = time_distance / self.seconds_per_point;
+            // let point_distance = ( anchor_bucket_name.0 - bucket_name.0 ) % (self.points as u32);
+            let point_distance = time_distance / self.seconds_per_point;
+            // panic!("({}-{}) % {} = {}", anchor_bucket_name.0, bucket_name.0, self.points, point_distance);
+            let index = Archive::py_mod(point_distance, self.points as u32);
+            ArchiveIndex(index)
+        }
     }
 
     fn py_mod(input: u32, base: u32) -> u32 {
@@ -147,122 +147,226 @@ impl Archive {
 
     #[inline]
     pub fn anchor_bucket_name(&self) -> BucketName {
-    	let first_four_bytes = BigEndian::read_u32(&self.slice()[0..5]);
-    	BucketName( first_four_bytes )
+        let first_four_bytes = BigEndian::read_u32(&self.slice()[0..4]);
+        BucketName( first_four_bytes )
     }
 
     #[inline]
     fn slice(&self) -> &[u8] {
-		unsafe{ self.mmap_view.as_slice() }
+        unsafe{ self.mmap_view.as_slice() }
     }
 
     #[inline]
     fn mut_slice(&mut self) -> &mut [u8] {
-		unsafe{ self.mmap_view.as_mut_slice() }
+        unsafe{ self.mmap_view.as_mut_slice() }
     }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use super::super::super::point::Point;
-	use std::io::Cursor;
-	use std::io::Write;
-	use memmap::{ Mmap, Protection };
+    use super::*;
+    use super::super::super::point::Point;
+    use std::io::{Write, Cursor, Error};
+    use memmap::{ Mmap, Protection };
 
-	// ruby -e "%Q{`hexdump -v -e '"0x" 1/1 "%02X, "' blah.wsp`}.split(', ').each_slice(4){|arr| puts arr.join(',') + ',' }"
-	const SAMPLE_FILE_2 : [u8; 64] = [
-		0x00,0x00,0x00,0x01,
-		0x00,0x00,0x00,0x06,
-		0x3F,0x00,0x00,0x00,
-		0x00,0x00,0x00,0x01,
-		0x00,0x00,0x00,0x1C,
-		0x00,0x00,0x00,0x02,
-		0x00,0x00,0x00,0x03,
-		0x55,0xDA,0xA3,0x98,
-		0x40,0x59,0x00,0x00,
-		0x00,0x00,0x00,0x00,
-		0x55,0xDA,0xA3,0x9A,
-		0x40,0x59,0x00,0x00,
-		0x00,0x00,0x00,0x00,
-		0x55,0xDA,0xA3,0x9C,
-		0x40,0x59,0x00,0x00,
-		0x00,0x00,0x00,0x00,
-	];
+    // ruby -e "%Q{`hexdump -v -e '"0x" 1/1 "%02X, "' blah.wsp`}.split(', ').each_slice(4){|arr| puts arr.join(',') + ',' }"
+    const SAMPLE_FILE_2 : [u8; 64] = [
+        0x00,0x00,0x00,0x01,
+        0x00,0x00,0x00,0x06,
+        0x3F,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x01,
+        0x00,0x00,0x00,0x1C,
+        0x00,0x00,0x00,0x02,
+        0x00,0x00,0x00,0x03,
+        0x55,0xDA,0xA3,0x98,
+        0x40,0x59,0x00,0x00,
+        0x00,0x00,0x00,0x00,
+        0x55,0xDA,0xA3,0x9A,
+        0x40,0x59,0x00,0x00,
+        0x00,0x00,0x00,0x00,
+        0x55,0xDA,0xA3,0x9C,
+        0x40,0x59,0x00,0x00,
+        0x00,0x00,0x00,0x00,
+    ];
 
-	#[cfg(test)]
-	fn build_mmap() -> Mmap{
-		// Borrows from the archive bytes
-		let archive_data = &SAMPLE_FILE_2[28..];
-		assert_eq!(archive_data[0], 0x55);
+    #[cfg(test)]
+    fn build_mmap() -> Mmap{
+        // Borrows from the archive bytes
+        let archive_data = &SAMPLE_FILE_2[28..];
+        assert_eq!(archive_data[0], 0x55);
 
-		let mut anon_mmap = Mmap::anonymous(archive_data.len(), Protection::ReadWrite).unwrap();
-		{
-			let slice : &mut [u8] = unsafe{ anon_mmap.as_mut_slice() };
-			let mut cursor = Cursor::new(slice);
-			cursor.write(&archive_data[..]).unwrap();
-		};
+        let mut anon_mmap = Mmap::anonymous(archive_data.len(), Protection::ReadWrite).unwrap();
+        {
+            let slice : &mut [u8] = unsafe{ anon_mmap.as_mut_slice() };
+            let mut cursor = Cursor::new(slice);
+            cursor.write(&archive_data[..]).unwrap();
+        };
 
-		anon_mmap
-	}
+        anon_mmap
+    }
 
-	#[test]
-	fn test_archive_index(){
-		let anon_view = build_mmap().into_view_sync();
+    #[test]
+    fn test_archive_index(){
+        let anon_view = build_mmap().into_view_sync();
 
-		let archive = Archive::new(2, 3, anon_view);
+        let archive = Archive::new(2, 3, anon_view);
 
-		// Our bucket names are aligned, ts normalization is working
-		assert_eq!(archive.bucket_name(1440392088).0, 1440392088);
-		assert_eq!(archive.bucket_name(1440392090).0, 1440392090);
-		assert_eq!(archive.bucket_name(1440392092).0, 1440392092);
+        // Our bucket names are aligned, ts normalization is working
+        assert_eq!(archive.bucket_name(1440392088).0, 1440392088);
+        assert_eq!(archive.bucket_name(1440392090).0, 1440392090);
+        assert_eq!(archive.bucket_name(1440392092).0, 1440392092);
 
-		// Assert absolute index in to archive
-		assert_eq!(archive.archive_index(&BucketName(1440392088)).0, 0);
-		assert_eq!(archive.archive_index(&BucketName(1440392090)).0, 1);
-		assert_eq!(archive.archive_index(&BucketName(1440392092)).0, 2);
+        // Assert absolute index in to archive
+        assert_eq!(archive.archive_index(&BucketName(1440392088)).0, 0);
+        assert_eq!(archive.archive_index(&BucketName(1440392090)).0, 1);
+        assert_eq!(archive.archive_index(&BucketName(1440392092)).0, 2);
 
-		// Now wrap around going down
-		assert_eq!(archive.archive_index(&BucketName(1440392086)).0, 2);
-		assert_eq!(archive.archive_index(&BucketName(1440392084)).0, 1);
-		assert_eq!(archive.archive_index(&BucketName(1440392082)).0, 0);
+        // Now wrap around going down
+        assert_eq!(archive.archive_index(&BucketName(1440392086)).0, 2);
+        assert_eq!(archive.archive_index(&BucketName(1440392084)).0, 1);
+        assert_eq!(archive.archive_index(&BucketName(1440392082)).0, 0);
 
-		// Wrap around going up
-		assert_eq!(archive.archive_index(&BucketName(1440392094)).0, 0);
-		assert_eq!(archive.archive_index(&BucketName(1440392096)).0, 1);
-		assert_eq!(archive.archive_index(&BucketName(1440392098)).0, 2);
-	}
+        // Wrap around going up
+        assert_eq!(archive.archive_index(&BucketName(1440392094)).0, 0);
+        assert_eq!(archive.archive_index(&BucketName(1440392096)).0, 1);
+        assert_eq!(archive.archive_index(&BucketName(1440392098)).0, 2);
+    }
 
-	#[test]
-	fn test_read(){
-		let anon_view = build_mmap().into_view_sync();
-		let mut archive = Archive::new(2, 3, anon_view);
-		assert_eq!(archive.anchor_bucket_name(), BucketName(1440392088) );
-		assert_eq!(archive.seconds_per_point(), 2);
-		assert_eq!(archive.points(), 3);
-		assert_eq!(archive.size(), 36);
-		assert_eq!(archive.archive_index(&BucketName(1440392088)), ArchiveIndex(0));
+    #[test]
+    fn test_read_from_start(){
+        let anon_view = build_mmap().into_view_sync();
+        let mut archive = Archive::new(2, 3, anon_view);
+        assert_eq!(archive.anchor_bucket_name(), BucketName(1440392088) );
+        assert_eq!(archive.seconds_per_point(), 2);
+        assert_eq!(archive.points(), 3);
+        assert_eq!(archive.size(), 36);
+        assert_eq!(archive.archive_index(&BucketName(1440392088)), ArchiveIndex(0));
 
-		{
-			let mut points_buf = Vec::with_capacity(3);
-			unsafe{ points_buf.set_len(3) };
-			archive.read_points(BucketName(0), &mut points_buf[..]);
-			let expected = vec![
-				Point(1440392088, 100.0),
-				Point(1440392090, 100.0),
-				Point(1440392092, 100.0)
-			];
-			assert_eq!(points_buf, expected);
+        {
+            let mut points_buf = Vec::with_capacity(3);
+            unsafe{ points_buf.set_len(3) };
+            let read_result = archive.read_points(BucketName(0), &mut points_buf[..]);
+            let expected = vec![
+                Point(1440392088, 100.0),
+                Point(1440392090, 100.0),
+                Point(1440392092, 100.0)
+            ];
+            assert!(read_result.is_ok());
+            assert_eq!(points_buf, expected);
 
-			let point = Point(1440392090,8.0);
-			let bucket_name = BucketName(point.0);
-			archive.write(&point);
-			assert_eq!(archive.archive_index(&bucket_name).0, 1);
+            let point = Point(1440392090,8.0);
+            let bucket_name = BucketName(point.0);
+            archive.write(&point);
+            assert_eq!(archive.archive_index(&bucket_name).0, 1);
 
-			unsafe{ points_buf.set_len(1) };
-			archive.read_points(bucket_name, &mut points_buf[..]);
-			assert_eq!(points_buf[0].0, 1440392090);
-			assert_eq!(points_buf[0].1, 8.0);
-		}
-	}
+            unsafe{ points_buf.set_len(1) };
+            let read_result = archive.read_points(bucket_name, &mut points_buf[..]);
+            assert!(read_result.is_ok());
+            assert_eq!(points_buf[0].0, 1440392090);
+            assert_eq!(points_buf[0].1, 8.0);
+        }
+    }
+
+    #[test]
+    fn test_read_from_middle(){
+        let anon_view = build_mmap().into_view_sync();
+        let mut archive = Archive::new(2, 3, anon_view);
+        assert_eq!(archive.anchor_bucket_name(), BucketName(1440392088) );
+        assert_eq!(archive.seconds_per_point(), 2);
+        assert_eq!(archive.points(), 3);
+        assert_eq!(archive.size(), 36);
+        assert_eq!(archive.archive_index(&BucketName(1440392088)), ArchiveIndex(0));
+
+        {
+            let mut points_buf = Vec::with_capacity(3);
+            unsafe{ points_buf.set_len(3) };
+            let read_result = archive.read_points(BucketName(archive.seconds_per_point * 1), &mut points_buf[..]);
+            let expected = vec![
+                Point(1440392090, 100.0),
+                Point(1440392092, 100.0),
+                Point(1440392088, 100.0)
+            ];
+            assert!(read_result.is_ok());
+            assert_eq!(points_buf, expected);
+        }
+    }
+
+    #[test]
+    fn test_read_from_end(){
+        let anon_view = build_mmap().into_view_sync();
+        let mut archive = Archive::new(2, 3, anon_view);
+        assert_eq!(archive.anchor_bucket_name(), BucketName(1440392088) );
+        assert_eq!(archive.seconds_per_point(), 2);
+        assert_eq!(archive.points(), 3);
+        assert_eq!(archive.size(), 36);
+        assert_eq!(archive.archive_index(&BucketName(1440392088)), ArchiveIndex(0));
+
+        {
+            let mut points_buf = Vec::with_capacity(3);
+            unsafe{ points_buf.set_len(3) };
+            let read_result = archive.read_points(BucketName(archive.seconds_per_point * 2), &mut points_buf[..]);
+            let expected = vec![
+                Point(1440392092, 100.0),
+                Point(1440392088, 100.0),
+                Point(1440392090, 100.0)
+            ];
+            assert!(read_result.is_ok());
+            assert_eq!(points_buf, expected);
+        }
+    }
+
+    #[test]
+    fn test_read_too_large() {
+        let anon_view = build_mmap().into_view_sync();
+        let mut archive = Archive::new(2, 3, anon_view);
+        assert_eq!(archive.anchor_bucket_name(), BucketName(1440392088) );
+        assert_eq!(archive.seconds_per_point(), 2);
+        assert_eq!(archive.points(), 3);
+        assert_eq!(archive.size(), 36);
+        assert_eq!(archive.archive_index(&BucketName(1440392088)), ArchiveIndex(0));
+
+        let mut points_buf = Vec::with_capacity(4);
+        unsafe{ points_buf.set_len(4) };
+        let read_result = archive.read_points(BucketName(0), &mut points_buf[..]);
+        assert_eq!(format!("{}", read_result.unwrap_err()), "Points requested exceeds archive retention period. Requested: 4, Available: 3");
+    }
+
+    #[test]
+    fn test_write(){
+        /* Create empty archive with 3 sampling rates:
+         * 1s; 1min
+         * 5s; 1hour
+         * 15s; 1day
+        */
+
+        let anon_view = build_mmap().into_view_sync();
+        let mut archive = Archive::new(2, 3, anon_view);
+        assert_eq!(archive.anchor_bucket_name(), BucketName(1440392088) );
+        assert_eq!(archive.seconds_per_point(), 2);
+        assert_eq!(archive.points(), 3);
+        assert_eq!(archive.size(), 36);
+        assert_eq!(archive.archive_index(&BucketName(1440392088)), ArchiveIndex(0));
+
+        {
+            let mut points_buf = Vec::with_capacity(3);
+            unsafe{ points_buf.set_len(3) };
+            archive.read_points(BucketName(0), &mut points_buf[..]);
+            let expected = vec![
+                Point(1440392088, 100.0),
+                Point(1440392090, 100.0),
+                Point(1440392092, 100.0)
+            ];
+            assert_eq!(points_buf, expected);
+
+            let point = Point(1440392090,8.0);
+            let bucket_name = BucketName(point.0);
+            archive.write(&point);
+            assert_eq!(archive.archive_index(&bucket_name).0, 1);
+
+            unsafe{ points_buf.set_len(1) };
+            archive.read_points(bucket_name, &mut points_buf[..]);
+            assert_eq!(points_buf[0].0, 1440392090);
+            assert_eq!(points_buf[0].1, 8.0);
+        }
+    }
 }

--- a/src/whisper/file/archive.rs
+++ b/src/whisper/file/archive.rs
@@ -53,7 +53,7 @@ impl Archive {
 
     pub fn read_points(&self, from: BucketName, points: &mut[Point]) -> Result<()> {
         if self.points() < points.len() {
-          return Err(Error::new(ErrorKind::InvalidInput, format!("Points requested exceeds archive retention period. Requested: {}, Available: {}", points.len(), self.points())));
+            return Err(Error::new(ErrorKind::InvalidInput, format!("Points requested exceeds archive retention period. Requested: {}, Available: {}", points.len(), self.points())));
         }
 
         let start = self.archive_index(&from);
@@ -73,7 +73,7 @@ impl Archive {
 
             let (first_buf, second_buf) = points.split_at_mut(first_data.chunks(point::POINT_SIZE).len());
             Archive::write_data_as_points_to_slice(first_data, first_buf).and_then(|_| {
-              Archive::write_data_as_points_to_slice(second_data, second_buf)
+                Archive::write_data_as_points_to_slice(second_data, second_buf)
             })
         } else {
             let start_index = start.0 as usize * point::POINT_SIZE;

--- a/src/whisper/file/archive.rs
+++ b/src/whisper/file/archive.rs
@@ -154,7 +154,7 @@ impl Archive {
     }
 
     #[inline]
-    fn slice(&self) -> &[u8] {
+    pub fn slice(&self) -> &[u8] {
         unsafe{ self.mmap_view.as_slice() }
     }
 
@@ -168,7 +168,7 @@ impl Archive {
 mod tests {
     use super::*;
     use super::super::super::point::Point;
-    use std::io::{Write, Cursor, Error};
+    use std::io::{Write, Cursor};
     use memmap::{ Mmap, Protection };
 
     // ruby -e "%Q{`hexdump -v -e '"0x" 1/1 "%02X, "' blah.wsp`}.split(', ').each_slice(4){|arr| puts arr.join(',') + ',' }"
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn test_read_from_middle(){
         let anon_view = build_mmap().into_view_sync();
-        let mut archive = Archive::new(2, 3, anon_view);
+        let archive = Archive::new(2, 3, anon_view);
         assert_eq!(archive.anchor_bucket_name(), BucketName(1440392088) );
         assert_eq!(archive.seconds_per_point(), 2);
         assert_eq!(archive.points(), 3);
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     fn test_read_from_end(){
         let anon_view = build_mmap().into_view_sync();
-        let mut archive = Archive::new(2, 3, anon_view);
+        let archive = Archive::new(2, 3, anon_view);
         assert_eq!(archive.anchor_bucket_name(), BucketName(1440392088) );
         assert_eq!(archive.seconds_per_point(), 2);
         assert_eq!(archive.points(), 3);
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn test_read_too_large() {
         let anon_view = build_mmap().into_view_sync();
-        let mut archive = Archive::new(2, 3, anon_view);
+        let archive = Archive::new(2, 3, anon_view);
         assert_eq!(archive.anchor_bucket_name(), BucketName(1440392088) );
         assert_eq!(archive.seconds_per_point(), 2);
         assert_eq!(archive.points(), 3);
@@ -352,7 +352,7 @@ mod tests {
         {
             let mut points_buf = Vec::with_capacity(3);
             unsafe{ points_buf.set_len(3) };
-            archive.read_points(BucketName(0), &mut points_buf[..]);
+            archive.read_points(BucketName(0), &mut points_buf[..]).unwrap();
             let expected = vec![
                 Point(1440392088, 100.0),
                 Point(1440392090, 100.0),
@@ -366,7 +366,7 @@ mod tests {
             assert_eq!(archive.archive_index(&bucket_name).0, 1);
 
             unsafe{ points_buf.set_len(1) };
-            archive.read_points(bucket_name, &mut points_buf[..]);
+            archive.read_points(bucket_name, &mut points_buf[..]).unwrap();
             assert_eq!(points_buf[0].0, 1440392090);
             assert_eq!(points_buf[0].1, 8.0);
         }

--- a/src/whisper/file/header.rs
+++ b/src/whisper/file/header.rs
@@ -8,15 +8,38 @@ use super::super::point;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum AggregationType {
-	Average,
-	Unknown
+        Average,
+	Sum
+}
+
+impl AggregationType {
+  pub fn aggregate(&self, points: &[point::Point], range: u32) -> f64 {
+      match *self {
+        AggregationType::Average => {
+          let count = points.iter()
+            .filter(|&&point::Point(t, _)| t >= range)
+            .count();
+          let sum = points
+            .iter()
+            .filter(|&&point::Point(t, _)| t >= range)
+            .map(|&point::Point(_, n)| n)
+            .sum::<f64>();
+          if sum == 0.0 { 0.0 } else { sum / count as f64}
+        },
+        AggregationType::Sum => points
+          .iter()
+          .filter(|&&point::Point(t, _)| t >= range)
+          .map(|&point::Point(_, n)| n)
+          .sum::<f64>()
+      }
+    }
 }
 
 impl fmt::Display for AggregationType {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
 			AggregationType::Average => write!(f, "average"),
-			AggregationType::Unknown => write!(f, "unknown")
+			AggregationType::Sum => write!(f, "sum")
 		}
 	}
 }
@@ -24,14 +47,14 @@ impl fmt::Display for AggregationType {
 impl AggregationType {
 	pub fn from_u32(val: u32) -> AggregationType {
 		match val {
-			_ => AggregationType::Unknown
+			_ => AggregationType::Average
 		}
 	}
 
 	pub fn to_u32(&self) -> u32 {
 		match *self {
 			AggregationType::Average => 0,
-			AggregationType::Unknown => 10
+			AggregationType::Sum => 10
 		}
 	}
 }

--- a/src/whisper/file/header.rs
+++ b/src/whisper/file/header.rs
@@ -38,14 +38,15 @@ impl fmt::Display for AggregationType {
 impl AggregationType {
 	pub fn from_u32(val: u32) -> AggregationType {
 		match val {
-			_ => AggregationType::Average
+			2 => AggregationType::Sum,
+			_  => AggregationType::Average
 		}
 	}
 
 	pub fn to_u32(&self) -> u32 {
 		match *self {
-			AggregationType::Average => 0,
-			AggregationType::Sum => 10
+			AggregationType::Average => 1,
+			AggregationType::Sum => 2
 		}
 	}
 }

--- a/src/whisper/file/header.rs
+++ b/src/whisper/file/header.rs
@@ -6,10 +6,10 @@ use byteorder::{ ByteOrder, BigEndian };
 use super::archive::{ self, Archive };
 use super::super::point;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum AggregationType {
-        Average,
-	Sum
+        Average = 1,
+	Sum = 2
 }
 
 impl AggregationType {
@@ -40,13 +40,6 @@ impl AggregationType {
 		match val {
 			2 => AggregationType::Sum,
 			_  => AggregationType::Average
-		}
-	}
-
-	pub fn to_u32(&self) -> u32 {
-		match *self {
-			AggregationType::Average => 1,
-			AggregationType::Sum => 2
 		}
 	}
 }

--- a/src/whisper/file/header.rs
+++ b/src/whisper/file/header.rs
@@ -8,21 +8,21 @@ use super::super::point;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum AggregationType {
-        Average = 1,
-	Sum = 2
+    Average = 1,
+    Sum = 2
 }
 
 impl AggregationType {
-  pub fn aggregate(&self, points: &[point::Point]) -> f64 {
-      match *self {
-        AggregationType::Average => {
-          if points.is_empty() { return 0.0 };
-          let count = points.len() as f64;
-          let sum: f64 = points.iter().map(point::Point::value).sum();
-          sum / count
-        },
-        AggregationType::Sum => points.iter().map(point::Point::value).sum()
-      }
+    pub fn aggregate(&self, points: &[point::Point]) -> f64 {
+        match *self {
+            AggregationType::Average => {
+                if points.is_empty() { return 0.0 };
+                let count = points.len() as f64;
+                let sum: f64 = points.iter().map(point::Point::value).sum();
+                sum / count
+            },
+            AggregationType::Sum => points.iter().map(point::Point::value).sum()
+        }
     }
 }
 

--- a/src/whisper/file/header.rs
+++ b/src/whisper/file/header.rs
@@ -13,24 +13,15 @@ pub enum AggregationType {
 }
 
 impl AggregationType {
-  pub fn aggregate(&self, points: &[point::Point], range: u32) -> f64 {
+  pub fn aggregate(&self, points: &[point::Point]) -> f64 {
       match *self {
         AggregationType::Average => {
-          let count = points.iter()
-            .filter(|&&point::Point(t, _)| t >= range)
-            .count();
-          let sum = points
-            .iter()
-            .filter(|&&point::Point(t, _)| t >= range)
-            .map(|&point::Point(_, n)| n)
-            .sum::<f64>();
-          if sum == 0.0 { 0.0 } else { sum / count as f64}
+          if points.is_empty() { return 0.0 };
+          let count = points.len() as f64;
+          let sum: f64 = points.iter().map(point::Point::value).sum();
+          sum / count
         },
-        AggregationType::Sum => points
-          .iter()
-          .filter(|&&point::Point(t, _)| t >= range)
-          .map(|&point::Point(_, n)| n)
-          .sum::<f64>()
+        AggregationType::Sum => points.iter().map(point::Point::value).sum()
       }
     }
 }

--- a/src/whisper/file/mod.rs
+++ b/src/whisper/file/mod.rs
@@ -95,7 +95,7 @@ impl WhisperFile {
 
 		let header = Header::new(agg, schema.max_retention(), xff);
 		{
-			try!( opened_file.write_u32::<BigEndian>( header.aggregation_type.to_u32() ));
+			try!( opened_file.write_u32::<BigEndian>( header.aggregation_type as u32));
 			try!( opened_file.write_u32::<BigEndian>( header.max_retention ) );
 			try!( opened_file.write_f32::<BigEndian>( header.x_files_factor ) );
 			try!( opened_file.write_u32::<BigEndian>( schema.retention_policies.len() as u32 ) );
@@ -226,7 +226,7 @@ impl WhisperFile {
             use whisper::POINT_SIZE;
             let archives_start = Header::archives_start(self.archives.len());
             let mut bytes: Vec<u8> = vec![];
-            try!(bytes.write_u32::<BigEndian>(self.header.aggregation_type.to_u32()));
+            try!(bytes.write_u32::<BigEndian>(self.header.aggregation_type as u32));
             try!(bytes.write_u32::<BigEndian>(self.header.max_retention() as u32));
             try!(bytes.write_f32::<BigEndian>(self.header.x_files_factor()));
             try!(bytes.write_u32::<BigEndian>(self.archives.len() as u32));

--- a/src/whisper/file/mod.rs
+++ b/src/whisper/file/mod.rs
@@ -152,9 +152,9 @@ impl WhisperFile {
             if elapsed < 0 || elapsed as u32 >= self.header.max_retention() { return; }
 
             enum WriteState {
-              Initial,
-              Aggregate(usize),
-              Finished
+                Initial,
+                Aggregate(usize),
+                Finished
             };
 
             (0..self.archives.len()).fold(WriteState::Initial, |state, index| {
@@ -169,32 +169,32 @@ impl WhisperFile {
                   },
 
                   WriteState::Aggregate(last_index) => {
-                    let (points, timestamp, ratio) = {
-                        let seconds_per_point = self.archives[index].seconds_per_point();
-                        let ref last_archive = self.archives[last_index];
-                        let candidate_point_count = cmp::min((seconds_per_point / last_archive.seconds_per_point()) as usize, last_archive.points());
-                        let timestamp = point.0 - (point.0 % seconds_per_point);
-                        let from = archive::BucketName(timestamp);
-                        let mut candidate_points: Vec<Point> = repeat(Point::default()).take(candidate_point_count).collect();
-                        last_archive.read_points(from, &mut candidate_points).unwrap();
-                        let points = candidate_points
-                            .into_iter()
-                            .enumerate()
-                            .filter(|&(i, Point(t, _))| timestamp + (i as u32) * last_archive.seconds_per_point() == t)
-                            .map(|(_, p)| p)
-                            .collect::<Vec<Point>>();
-                        let ratio = points.len() as f32 / candidate_point_count as f32;
-                        (points, timestamp, ratio)
-                    };
+                      let (points, timestamp, ratio) = {
+                          let seconds_per_point = self.archives[index].seconds_per_point();
+                          let ref last_archive = self.archives[last_index];
+                          let candidate_point_count = cmp::min((seconds_per_point / last_archive.seconds_per_point()) as usize, last_archive.points());
+                          let timestamp = point.0 - (point.0 % seconds_per_point);
+                          let from = archive::BucketName(timestamp);
+                          let mut candidate_points: Vec<Point> = repeat(Point::default()).take(candidate_point_count).collect();
+                          last_archive.read_points(from, &mut candidate_points).unwrap();
+                          let points = candidate_points
+                              .into_iter()
+                              .enumerate()
+                              .filter(|&(i, Point(t, _))| timestamp + (i as u32) * last_archive.seconds_per_point() == t)
+                              .map(|(_, p)| p)
+                              .collect::<Vec<Point>>();
+                          let ratio = points.len() as f32 / candidate_point_count as f32;
+                          (points, timestamp, ratio)
+                      };
 
-                    if ratio >= self.header.x_files_factor() {
-                        point.0 = timestamp;
-                        point.1 = self.header.aggregation_type().aggregate(&points);
-                        self.archives[index].write(&point);
-                        WriteState::Aggregate(index)
-                    } else {
-                        WriteState::Finished
-                    }
+                      if ratio >= self.header.x_files_factor() {
+                          point.0 = timestamp;
+                          point.1 = self.header.aggregation_type().aggregate(&points);
+                          self.archives[index].write(&point);
+                          WriteState::Aggregate(index)
+                      } else {
+                          WriteState::Finished
+                      }
                   },
 
                   WriteState::Finished => WriteState::Finished
@@ -259,20 +259,20 @@ mod tests {
          *   hexdump -v -e '"0x" 1/1 "%02X, "' <filename>
         */
 	const SAMPLE_EMPTY_FILE : [u8; 88] = [
-		0x00, 0x00, 0x00, 0x01, // agg type = 1 = Average
-		0x00, 0x00, 0x01, 0x2C, // max ret
-		0x3F, 0x00, 0x00, 0x00, // xff = 0.5
-		0x00, 0x00, 0x00, 0x01, // archive count = 1
-		0x00, 0x00, 0x00, 0x1C, // a1 offset
-		0x00, 0x00, 0x00, 0x3C, // a1 secs/point
-		0x00, 0x00, 0x00, 0x05, // a1 points
+            0x00, 0x00, 0x00, 0x01, // agg type = 1 = Average
+            0x00, 0x00, 0x01, 0x2C, // max ret
+            0x3F, 0x00, 0x00, 0x00, // xff = 0.5
+            0x00, 0x00, 0x00, 0x01, // archive count = 1
+            0x00, 0x00, 0x00, 0x1C, // a1 offset
+            0x00, 0x00, 0x00, 0x3C, // a1 secs/point
+            0x00, 0x00, 0x00, 0x05, // a1 points
 
-	// A1: 60 seconds per point, 5 minutes = 5 points
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+            // A1: 60 seconds per point, 5 minutes = 5 points
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	];
 
         /* Sample File 1
@@ -470,15 +470,15 @@ mod tests {
             let schema = Schema::new_from_retention_specs(default_specs).unwrap();
             let mut file = WhisperFile::new_transient(&schema, header::AggregationType::Average, 0.0);
             for &(t, v) in [
-              (1487974954, 1.0),
-              (1487974956, 3.0),
-              (1487974959, 9.0),
-              (1487974962, 15.0),
-              (1487974965, 65.0),
-              (1487974968, 122.0),
-              (1487974970, 133.0)
+                (1487974954, 1.0),
+                (1487974956, 3.0),
+                (1487974959, 9.0),
+                (1487974962, 15.0),
+                (1487974965, 65.0),
+                (1487974968, 122.0),
+                (1487974970, 133.0)
             ].iter() {
-              file._write(&Point(t, v), t as i64);
+                file._write(&Point(t, v), t as i64);
             }
             let result: Vec<u8> = file.into_bytes().unwrap();
             assert_eq!(result, sample);

--- a/src/whisper/file/mod.rs
+++ b/src/whisper/file/mod.rs
@@ -5,10 +5,10 @@ use time;
 mod header;
 pub mod archive;
 
-use self::header::{ Header, AggregationType };
+use self::header::Header;
 use self::archive::Archive;
 
-pub use self::header::STATIC_HEADER_SIZE;
+pub use self::header::{STATIC_HEADER_SIZE, AggregationType};
 pub use self::archive::ARCHIVE_INFO_SIZE;
 
 use whisper::Point;
@@ -58,7 +58,7 @@ Archive {} data:
 ", index, offset, archive.seconds_per_point(), archive.points(), archive.seconds_per_point() * archive.points() as u32, archive.size(), index ));
 
 			unsafe{ points_buf.set_len(archive.points()) };
-			archive.read_points(archive.anchor_bucket_name(), &mut points_buf[..]);
+			try!(archive.read_points(archive.anchor_bucket_name(), &mut points_buf).map_err(|_| fmt::Error));
 
 			let mut points_index = 0;
 			for point in &points_buf {
@@ -75,27 +75,8 @@ Archive {} data:
 	}
 }
 
-
 impl WhisperFile {
-        fn new_transient(schema: &Schema) -> WhisperFile {
-            let path = "/dev/null".into();
-            let header = Header::new(AggregationType::Average, schema.max_retention(), 0.0);
-            let archives = schema.retention_policies.iter().map(|policy| {
-                Archive::new(
-                    policy.precision,
-                    policy.points() as usize,
-                    Mmap::anonymous(policy.size_on_disk() as usize, Protection::ReadWrite).unwrap().into_view_sync()
-                )
-            }).collect();
-
-            WhisperFile {
-                path: path,
-                header: header,
-                archives: archives
-            }
-        }
-
-	pub fn new<P>(path: P, schema: &Schema) -> io::Result<WhisperFile>
+	pub fn new<P>(path: P, schema: &Schema, agg: AggregationType, xff: f32) -> io::Result<WhisperFile>
         where P: AsRef<Path> {
 		let mut opened_file = try!(OpenOptions::new().read(true).write(true).create(true).open(path.as_ref()));
 
@@ -112,8 +93,7 @@ impl WhisperFile {
 			}
 		}
 
-		let xff = 0.5;
-		let header = Header::new(AggregationType::Average, schema.max_retention(), xff);
+		let header = Header::new(agg, schema.max_retention(), xff);
 		{
 			try!( opened_file.write_u32::<BigEndian>( header.aggregation_type.to_u32() ));
 			try!( opened_file.write_u32::<BigEndian>( header.max_retention ) );
@@ -169,6 +149,7 @@ impl WhisperFile {
 	fn _write(&mut self, point: &Point, now: i64) {
             let mut point = point.clone();
             let elapsed = now - point.0 as i64;
+            if elapsed < 0 || elapsed as u32 >= self.header.max_retention() { return; }
 
             enum WriteState {
               Initial,
@@ -179,40 +160,40 @@ impl WhisperFile {
             (0..self.archives.len()).fold(WriteState::Initial, |state, index| {
                 match state {
                   WriteState::Initial => {
-                    if elapsed < 0 || elapsed as usize >= self.archives[index].retention() {
-                      WriteState::Initial
-                    } else {
-                      self.archives[index].write(&point);
-                      WriteState::Aggregate(index)
-                    }
+                      if elapsed as usize >= self.archives[index].retention() {
+                          WriteState::Initial
+                      } else {
+                          self.archives[index].write(&point);
+                          WriteState::Aggregate(index)
+                      }
                   },
 
                   WriteState::Aggregate(last_index) => {
                     let (points, timestamp, ratio) = {
-                      let seconds_per_point = self.archives[index].seconds_per_point();
-                      let ref last_archive = self.archives[last_index];
-                      let candidate_point_count = cmp::min((seconds_per_point / last_archive.seconds_per_point()) as usize, last_archive.points());
-                      let timestamp = point.0 - (point.0 % seconds_per_point);
-                      let from = archive::BucketName(timestamp);
-                      let mut candidate_points: Vec<Point> = repeat(Point::default()).take(candidate_point_count).collect();
-                      last_archive.read_points(from, &mut candidate_points).unwrap();
-                      let points = candidate_points
-                        .into_iter()
-                        .enumerate()
-                        .filter(|&(i, Point(t, v))| timestamp + (i as u32) * last_archive.seconds_per_point() == t)
-                        .map(|(_, p)| p)
-                        .collect::<Vec<Point>>();
-                      let ratio = points.len() as f32 / candidate_point_count as f32;
-                      (points, timestamp, ratio)
+                        let seconds_per_point = self.archives[index].seconds_per_point();
+                        let ref last_archive = self.archives[last_index];
+                        let candidate_point_count = cmp::min((seconds_per_point / last_archive.seconds_per_point()) as usize, last_archive.points());
+                        let timestamp = point.0 - (point.0 % seconds_per_point);
+                        let from = archive::BucketName(timestamp);
+                        let mut candidate_points: Vec<Point> = repeat(Point::default()).take(candidate_point_count).collect();
+                        last_archive.read_points(from, &mut candidate_points).unwrap();
+                        let points = candidate_points
+                            .into_iter()
+                            .enumerate()
+                            .filter(|&(i, Point(t, _))| timestamp + (i as u32) * last_archive.seconds_per_point() == t)
+                            .map(|(_, p)| p)
+                            .collect::<Vec<Point>>();
+                        let ratio = points.len() as f32 / candidate_point_count as f32;
+                        (points, timestamp, ratio)
                     };
 
                     if ratio >= self.header.x_files_factor() {
-                      point.0 = timestamp;
-                      point.1 = self.header.aggregation_type().aggregate(&points);
-                      self.archives[index].write(&point);
-                      WriteState::Aggregate(index)
+                        point.0 = timestamp;
+                        point.1 = self.header.aggregation_type().aggregate(&points);
+                        self.archives[index].write(&point);
+                        WriteState::Aggregate(index)
                     } else {
-                      WriteState::Finished
+                        WriteState::Finished
                     }
                   },
 
@@ -221,12 +202,44 @@ impl WhisperFile {
             });
 	}
 
-        fn read_all(&self) -> Vec<Vec<Point>> {
-            self.archives.iter().map(|archive| {
-                let mut points: Vec<Point> = repeat(Point::default()).take(archive.points()).collect();
-                archive.read_points(archive.anchor_bucket_name(), &mut points).unwrap();
-                points
-            }).collect()
+        #[cfg(test)]
+        fn new_transient(schema: &Schema, agg: AggregationType, xff: f32) -> WhisperFile {
+            let path = "/dev/null".into();
+            let header = Header::new(agg, schema.max_retention(), xff);
+            let archives = schema.retention_policies.iter().map(|policy| {
+                Archive::new(
+                    policy.precision,
+                    policy.points() as usize,
+                    Mmap::anonymous(policy.size_on_disk() as usize, Protection::ReadWrite).unwrap().into_view_sync()
+                )
+            }).collect();
+
+            WhisperFile {
+                path: path,
+                header: header,
+                archives: archives
+            }
+        }
+
+        #[cfg(test)]
+        fn into_bytes(self) -> io::Result<Vec<u8>> {
+            use whisper::POINT_SIZE;
+            let archives_start = Header::archives_start(self.archives.len());
+            let mut bytes: Vec<u8> = vec![];
+            try!(bytes.write_u32::<BigEndian>(self.header.aggregation_type.to_u32()));
+            try!(bytes.write_u32::<BigEndian>(self.header.max_retention() as u32));
+            try!(bytes.write_f32::<BigEndian>(self.header.x_files_factor()));
+            try!(bytes.write_u32::<BigEndian>(self.archives.len() as u32));
+            try!(self.archives.iter().fold(Ok(archives_start), |archive_offset: io::Result<usize>, archive| {
+                archive_offset.and_then(|offset| {
+                    try!(bytes.write_u32::<BigEndian>(offset as u32));
+                    try!(bytes.write_u32::<BigEndian>(archive.seconds_per_point()));
+                    try!(bytes.write_u32::<BigEndian>(archive.points() as u32));
+                    Ok(offset + archive.points() * POINT_SIZE)
+                })
+            }));
+            for archive in self.archives { bytes.extend_from_slice(archive.slice()); }
+            Ok(bytes)
         }
 }
 
@@ -234,47 +247,195 @@ impl WhisperFile {
 mod tests {
 	use whisper::{ Schema, WhisperFile, Point };
 	use super::header;
-        use super::time;
 
 	use std::io::Cursor;
 	use std::io::Write;
 	use memmap::{ Mmap, Protection };
 
-	// whisper-create.py blah.wsp 60:5
-	// hexdump -v -e '"0x" 1/1 "%02X, "' blah.wsp
-	const SAMPLE_FILE : [u8; 88] = [
-	//  agg type
-		0x00, 0x00, 0x00, 0x01,
-	//  max ret
-		0x00, 0x00, 0x01, 0x2C,
-	// x_files_factor
-		0x3F, 0x00, 0x00, 0x00,
-	// archive_count
-		0x00, 0x00, 0x00, 0x01,
-	// archive_info[0].offset
-		0x00, 0x00, 0x00, 0x1C,
-	// archive_info[0].seconds_per_point
-		0x00, 0x00, 0x00, 0x3C,
-	// archive_info[0].points
-		0x00, 0x00, 0x00, 0x05,
-	// archive[0] data
-		0x55, 0xD9, 0x33, 0xE8, 0x40, 0x59, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00
+        /* Sample Empty File
+         * Created with:
+         *   whisper-create.py <filename> 60:5
+	 * Viewed with:
+         *   hexdump -v -e '"0x" 1/1 "%02X, "' <filename>
+        */
+	const SAMPLE_EMPTY_FILE : [u8; 88] = [
+		0x00, 0x00, 0x00, 0x01, // agg type = 1 = Average
+		0x00, 0x00, 0x01, 0x2C, // max ret
+		0x3F, 0x00, 0x00, 0x00, // xff = 0.5
+		0x00, 0x00, 0x00, 0x01, // archive count = 1
+		0x00, 0x00, 0x00, 0x1C, // a1 offset
+		0x00, 0x00, 0x00, 0x3C, // a1 secs/point
+		0x00, 0x00, 0x00, 0x05, // a1 points
+
+	// A1: 60 seconds per point, 5 minutes = 5 points
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	];
+
+        /* Sample File 1
+         * Created with:
+         *   whisper-create.py --xFilesFactor=0.0 <filename> 1s:10s 10s:1m 1m:3m
+         *   whisper-update.py <filename> 1487974954 1
+         *   whisper-update.py <filename> 1487974956 3
+         *   whisper-update.py <filename> 1487974959 9
+         *   whisper-update.py <filename> 1487974962 15
+         *   whisper-update.py <filename> 1487974965 62
+         *   whisper-update.py <filename> 1487974968 122
+         *   whisper-update.py <filename> 1487974970 133
+        */
+        const SAMPLE_FILE_1: [u8; 280] = [
+            0x00, 0x00, 0x00, 0x01, // agg type = 1 = Average
+            0x00, 0x00, 0x00, 0xb4, // max ret = 180 = 3 minutes
+            0x00, 0x00, 0x00, 0x00, // xff = 0.0
+            0x00, 0x00, 0x00, 0x03, // archive count = 3
+            0x00, 0x00, 0x00, 0x34, // a1 offset
+            0x00, 0x00, 0x00, 0x01, // a1 secs/point
+            0x00, 0x00, 0x00, 0x0a, // a1 points
+            0x00, 0x00, 0x00, 0xac, // a2 offset
+            0x00, 0x00, 0x00, 0x0a, // a2 secs/point
+            0x00, 0x00, 0x00, 0x06, // a2 points
+            0x00, 0x00, 0x00, 0xf4, // a3 offset
+            0x00, 0x00, 0x00, 0x3c, // a3 secs/point
+            0x00, 0x00, 0x00, 0x03, // a3 points
+
+            // A1: 1 second per point, 10 seconds = 10 points
+            0x58, 0xb0, 0xb2, 0x2a, 0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x58, 0xb0, 0xb2, 0x35, 0x40, 0x50, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x58, 0xb0, 0xb2, 0x2c, 0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x58, 0xb0, 0xb2, 0x38, 0x40, 0x5e, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x58, 0xb0, 0xb2, 0x2f, 0x40, 0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x58, 0xb0, 0xb2, 0x3a, 0x40, 0x60, 0xa0, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x58, 0xb0, 0xb2, 0x32, 0x40, 0x2e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+            // A2: 10 seconds per point, 60 seconds = 6 points
+            0x58, 0xb0, 0xb2, 0x26, 0x40, 0x11, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
+            0x58, 0xb0, 0xb2, 0x30, 0x40, 0x50, 0xd5, 0x55, 0x55, 0x55, 0x55, 0x55,
+            0x58, 0xb0, 0xb2, 0x3a, 0x40, 0x60, 0xa0, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+            // A3: 1 minute per point, 3 minutes = 3 points
+            0x58, 0xb0, 0xb2, 0x08, 0x40, 0x51, 0x0e, 0x38, 0xe3, 0x8e, 0x38, 0xe3,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        ];
+
+        /* Sample File 2
+         * Created with:
+         *   whisper-create.py --xFilesFactor=0.33 <filename> 1s:6s 6s:30s 30s:3m
+         *   whisper-update.py <filename> 1487981304 0.35
+         *   whisper-update.py <filename> 1487981307 0.63
+         *   whisper-update.py <filename> 1487981310 0.71
+         *   whisper-update.py <filename> 1487981312 0.39
+         *   whisper-update.py <filename> 1487981314 0.59
+         *   whisper-update.py <filename> 1487981319 0.33
+         *   whisper-update.py <filename> 1487981323 0.17
+         *   whisper-update.py <filename> 1487981327 0.91
+         *   whisper-update.py <filename> 1487981330 0.79
+         *   whisper-update.py <filename> 1487981332 0.72
+        */
+        const SAMPLE_FILE_2: [u8; 256] = [
+            0x00, 0x00, 0x00, 0x01, // agg type = 1 = Average
+            0x00, 0x00, 0x00, 0xb4, // max ret = 180 = 3 minutes
+            0x3e, 0xa8, 0xf5, 0xc3, // xff = 0.33
+            0x00, 0x00, 0x00, 0x03, // archive count = 3
+            0x00, 0x00, 0x00, 0x34, // a1 offset
+            0x00, 0x00, 0x00, 0x01, // a1 secs/point
+            0x00, 0x00, 0x00, 0x06, // a1 points
+            0x00, 0x00, 0x00, 0x7c, // a2 offset
+            0x00, 0x00, 0x00, 0x06, // a2 secs/point
+            0x00, 0x00, 0x00, 0x05, // a2 points
+            0x00, 0x00, 0x00, 0xb8, // a3 offset
+            0x00, 0x00, 0x00, 0x1e, // a3 secs/point
+            0x00, 0x00, 0x00, 0x06, // a3 points
+
+            //A1: 1 second per point, 6 seconds = 6 points
+            0x58, 0xb0, 0xca, 0xfe, 0x3f, 0xe6, 0xb8, 0x51, 0xeb, 0x85, 0x1e, 0xb8,
+            0x58, 0xb0, 0xcb, 0x0b, 0x3f, 0xc5, 0xc2, 0x8f, 0x5c, 0x28, 0xf5, 0xc3,
+            0x58, 0xb0, 0xcb, 0x12, 0x3f, 0xe9, 0x47, 0xae, 0x14, 0x7a, 0xe1, 0x48,
+            0x58, 0xb0, 0xcb, 0x07, 0x3f, 0xd5, 0x1e, 0xb8, 0x51, 0xeb, 0x85, 0x1f,
+            0x58, 0xb0, 0xcb, 0x14, 0x3f, 0xe7, 0x0a, 0x3d, 0x70, 0xa3, 0xd7, 0x0a,
+            0x58, 0xb0, 0xcb, 0x0f, 0x3f, 0xed, 0x1e, 0xb8, 0x51, 0xeb, 0x85, 0x1f,
+
+            //A2: 6 seconds per point, 30 seconds = 5 points
+            0x58, 0xb0, 0xca, 0xf8, 0x3f, 0xdf, 0x5c, 0x28, 0xf5, 0xc2, 0x8f, 0x5c,
+            0x58, 0xb0, 0xca, 0xfe, 0x3f, 0xe2, 0x06, 0xd3, 0xa0, 0x6d, 0x3a, 0x07,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x58, 0xb0, 0xcb, 0x0a, 0x3f, 0xe1, 0x47, 0xae, 0x14, 0x7a, 0xe1, 0x48,
+            0x58, 0xb0, 0xcb, 0x10, 0x3f, 0xe8, 0x28, 0xf5, 0xc2, 0x8f, 0x5c, 0x29,
+
+            //A3: 30 seconds per point, 3 minutes = 6 points
+            0x58, 0xb0, 0xca, 0xfe, 0x3f, 0xe3, 0xd2, 0x7d, 0x27, 0xd2, 0x7d, 0x28,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        /* Sample File 3
+         * Created with:
+         *   whisper-create.py --xFilesFactor=0.25 --aggregationMethod=sum <filename> 4s:20s 20s:1m 1m:5m
+         *   whisper-update.py <filename> 1487986400 -607.16
+         *   whisper-update.py <filename> 1487986405 833.57
+         *   whisper-update.py <filename> 1487986411 512.61
+         *   whisper-update.py <filename> 1487986416 37.94
+         *   whisper-update.py <filename> 1487986420 -315
+         *   whisper-update.py <filename> 1487986427 871.87
+         *   whisper-update.py <filename> 1487986433 -862.63
+         *   whisper-update.py <filename> 1487986439 103.47
+         *   whisper-update.py <filename> 1487986443 -10.20
+         *   whisper-update.py <filename> 1487986448 366.01
+        */
+        const SAMPLE_FILE_3: [u8; 208] = [
+            0x00, 0x00, 0x00, 0x02, // agg type = 2 = Sum
+            0x00, 0x00, 0x01, 0x2c, // max ret = 300 = 5 minutes
+            0x3e, 0x80, 0x00, 0x00, // xff = 0.25
+            0x00, 0x00, 0x00, 0x03, // archive count = 3
+            0x00, 0x00, 0x00, 0x34, // a1 offset
+            0x00, 0x00, 0x00, 0x04, // a1 secs/point
+            0x00, 0x00, 0x00, 0x05, // a1 points
+            0x00, 0x00, 0x00, 0x70, // a2 offset
+            0x00, 0x00, 0x00, 0x14, // a2 secs/point
+            0x00, 0x00, 0x00, 0x03, // a2 points
+            0x00, 0x00, 0x00, 0x94, // a3 offset
+            0x00, 0x00, 0x00, 0x3c, // a3 secs/point
+            0x00, 0x00, 0x00, 0x05, // a3 points
+
+            // A1: 4 seconds per point, 20 seconds = 5 points
+            0x58, 0xb0, 0xdf, 0x08, 0xc0, 0x24, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+            0x58, 0xb0, 0xde, 0xf8, 0x40, 0x8b, 0x3e, 0xf5, 0xc2, 0x8f, 0x5c, 0x29,
+            0x58, 0xb0, 0xdf, 0x10, 0x40, 0x76, 0xe0, 0x28, 0xf5, 0xc2, 0x8f, 0x5c,
+            0x58, 0xb0, 0xdf, 0x00, 0xc0, 0x8a, 0xf5, 0x0a, 0x3d, 0x70, 0xa3, 0xd7,
+            0x58, 0xb0, 0xdf, 0x04, 0x40, 0x59, 0xde, 0x14, 0x7a, 0xe1, 0x47, 0xae,
+
+            // A2: 20 seconds per point, 60 seconds = 3 points
+            0x58, 0xb0, 0xde, 0xe0, 0x40, 0x88, 0x47, 0xae, 0x14, 0x7a, 0xe1, 0x48,
+            0x58, 0xb0, 0xde, 0xf4, 0xc0, 0x69, 0x49, 0x47, 0xae, 0x14, 0x7a, 0xe1,
+            0x58, 0xb0, 0xdf, 0x08, 0x40, 0x76, 0x3c, 0xf5, 0xc2, 0x8f, 0x5c, 0x29,
+
+            // A3: 1 minute per point, 5 minutes = 5 points
+            0x58, 0xb0, 0xde, 0xcc, 0x40, 0x81, 0xf5, 0x5c, 0x28, 0xf5, 0xc2, 0x90,
+            0x58, 0xb0, 0xdf, 0x08, 0x40, 0x76, 0x3c, 0xf5, 0xc2, 0x8f, 0x5c, 0x29,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        ];
 
 	#[test]
 	fn test_header(){
-		let mut anon_mmap = Mmap::anonymous(SAMPLE_FILE.len(), Protection::ReadWrite).unwrap();
+		let mut anon_mmap = Mmap::anonymous(SAMPLE_EMPTY_FILE.len(), Protection::ReadWrite).unwrap();
 		{
 			let slice : &mut [u8] = unsafe{ anon_mmap.as_mut_slice() };
 			let mut cursor = Cursor::new(slice);
-			cursor.write(&SAMPLE_FILE[..]).unwrap();
+			cursor.write(&SAMPLE_EMPTY_FILE[..]).unwrap();
 		};
 
 		let hdr = header::Header::new_from_slice(unsafe{ anon_mmap.as_mut_slice() });
@@ -297,52 +458,77 @@ mod tests {
 		let default_specs = vec!["1s:60s".to_string(), "1m:1y".to_string()];
 		let schema = Schema::new_from_retention_specs(default_specs).unwrap();
 
-		let mut file = WhisperFile::new(path, &schema).unwrap();
+		let mut file = WhisperFile::new(path, &schema, header::AggregationType::Average, 0.50).unwrap();
 
 		file.write(&Point(10, 0.0))
 	}
 
-        /*
 	#[test]
-	fn test_write_aggregation() {
-            let default_specs = vec!["1s:3s".to_string(), "1m:5m".to_string()];
+	fn test_aggregation_matches_py() {
+            let sample: &[u8] = &SAMPLE_FILE_1;
+            let default_specs = vec!["1s:10s".to_string(), "10s:1m".to_string(), "1m:3m".to_string()];
             let schema = Schema::new_from_retention_specs(default_specs).unwrap();
-            let mut file = WhisperFile::new_transient(&schema);
-
-            file.write(&Point(1, 1.1));
-            file.write(&Point(3, 3.1));
-            file.write(&Point(9, 9.1));
-            file.write(&Point(15, 15.1));
-            file.write(&Point(65, 65.1));
-
-            let result = file.read_all();
-            assert_eq!(result, vec![vec![]]);
-	}
-        */
-
-	#[test]
-	fn test_read_all() {
-            let default_specs = vec!["1s:60s".to_string(), "1m:5m".to_string()];
-            let schema = Schema::new_from_retention_specs(default_specs).unwrap();
-            let mut file = WhisperFile::new_transient(&schema);
+            let mut file = WhisperFile::new_transient(&schema, header::AggregationType::Average, 0.0);
             for &(t, v) in [
-              (2, 1.1),
-              (3, 3.1),
-              (9, 9.1),
-              (15, 15.1),
-              (65, 65.1),
-              (122, 122.1),
-              (133, 133.1)
+              (1487974954, 1.0),
+              (1487974956, 3.0),
+              (1487974959, 9.0),
+              (1487974962, 15.0),
+              (1487974965, 65.0),
+              (1487974968, 122.0),
+              (1487974970, 133.0)
             ].iter() {
-              file._write(&Point(1000 + t, v), 1000 + t as i64);
+              file._write(&Point(t, v), t as i64);
             }
-
-            let result = file.read_all();
-            assert_eq!(result, vec![vec![]]);
+            let result: Vec<u8> = file.into_bytes().unwrap();
+            assert_eq!(result, sample);
 	}
 
-	#[test]
-	fn test_write_outside_retention(){
+        #[test]
+	fn test_aggregation_matches_py_with_xff() {
+            let sample: &[u8] = &SAMPLE_FILE_2;
+            let default_specs = vec!["1s:6s".to_string(), "6s:30s".to_string(), "30s:3m".to_string()];
+            let schema = Schema::new_from_retention_specs(default_specs).unwrap();
+            let mut file = WhisperFile::new_transient(&schema, header::AggregationType::Average, 0.33);
+            for &(t, v) in [
+                (1487981304, 0.35),
+                (1487981307, 0.63),
+                (1487981310, 0.71),
+                (1487981312, 0.39),
+                (1487981314, 0.59),
+                (1487981319, 0.33),
+                (1487981323, 0.17),
+                (1487981327, 0.91),
+                (1487981330, 0.79),
+                (1487981332, 0.72),
+            ].iter() {
+                file._write(&Point(t, v), t as i64);
+            }
+            let result: Vec<u8> = file.into_bytes().unwrap();
+            assert_eq!(result, sample);
+        }
 
-	}
+        #[test]
+	fn test_aggregation_matches_py_with_sum() {
+            let sample: &[u8] = &SAMPLE_FILE_3;
+            let default_specs = vec!["4s:20s".to_string(), "20s:60s".to_string(), "1m:5m".to_string()];
+            let schema = Schema::new_from_retention_specs(default_specs).unwrap();
+            let mut file = WhisperFile::new_transient(&schema, header::AggregationType::Sum, 0.25);
+            for &(t, v) in [
+                (1487986400, -607.16),
+                (1487986405, 833.57),
+                (1487986411, 512.61),
+                (1487986416, 37.94),
+                (1487986420, -315.0),
+                (1487986427, 871.87),
+                (1487986433, -862.63),
+                (1487986439, 103.47),
+                (1487986443, -10.20),
+                (1487986448, 366.01),
+            ].iter() {
+                file._write(&Point(t, v), t as i64);
+            }
+            let result: Vec<u8> = file.into_bytes().unwrap();
+            assert_eq!(result, sample);
+        }
 }

--- a/src/whisper/mod.rs
+++ b/src/whisper/mod.rs
@@ -3,7 +3,7 @@ mod point;
 mod schema;
 mod cache;
 
-pub use self::file::WhisperFile;
-pub use self::point::Point;
+pub use self::file::{WhisperFile, AggregationType};
+pub use self::point::{Point, POINT_SIZE};
 pub use self::schema::Schema;
 pub use self::cache::{ WhisperCache, NamedPoint };

--- a/src/whisper/point.rs
+++ b/src/whisper/point.rs
@@ -11,6 +11,11 @@ pub struct Point(pub u32, pub f64);
 
 impl Point {
     #[inline]
+    pub fn value(&self) -> f64 {
+        self.1
+    }
+
+    #[inline]
     pub fn new_from_slice(slice: &[u8]) -> Point {
         let ts = BigEndian::read_u32(&slice[0..4]);
         let val = BigEndian::read_f64(&slice[4..]);

--- a/src/whisper/point.rs
+++ b/src/whisper/point.rs
@@ -10,18 +10,17 @@ pub const POINT_SIZE : usize = 12;
 pub struct Point(pub u32, pub f64);
 
 impl Point {
-	#[inline]
-	pub fn new_from_slice(slice: &[u8]) -> Point {
+    #[inline]
+    pub fn new_from_slice(slice: &[u8]) -> Point {
+        let ts = BigEndian::read_u32(&slice[0..4]);
+        let val = BigEndian::read_f64(&slice[4..]);
+        Point(ts,val)
+    }
 
-    	let ts = BigEndian::read_u32(&slice[0..4]);
-    	let val = BigEndian::read_f64(&slice[4..]);
-    	Point(ts,val)
-	}
-
-	#[inline]
-	pub fn write_to_slice(&self, bucket_name: BucketName, slice: &mut [u8]) {
-		let mut writer = Cursor::new(slice);
-		writer.write_u32::<BigEndian>(bucket_name.0).unwrap();
-		writer.write_f64::<BigEndian>(self.1).unwrap();
-	}
+    #[inline]
+    pub fn write_to_slice(&self, bucket_name: BucketName, slice: &mut [u8]) {
+        let mut writer = Cursor::new(slice);
+        writer.write_u32::<BigEndian>(bucket_name.0).unwrap();
+        writer.write_f64::<BigEndian>(self.1).unwrap();
+    }
 }

--- a/src/whisper/point.rs
+++ b/src/whisper/point.rs
@@ -6,7 +6,7 @@ use byteorder::{ ByteOrder, BigEndian, WriteBytesExt };
 
 pub const POINT_SIZE : usize = 12;
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug,PartialEq,Default,Clone)]
 pub struct Point(pub u32, pub f64);
 
 impl Point {


### PR DESCRIPTION
@xrl Adds downsampling on write to match the python implementation. Couple of interesting points I learned along the way that aren't necessarily fleshed out in the Whisper docs:

- Regardless of what your xff is, if a write timestamp is older than the highest-precision archive's retention period, but younger than the maximum retention for the db, the algorithm will keep climbing the ladder of archives until it finds the highest-precision fit for the initial write.

- If you're downsampling to an archive whose precision is longer than your previous archive's retention, it may fail to aggregate despite having plenty of data from within that precision. For example, if you're downsampling from an archive with 30s retention to an archive with 1m precision, your 30s-retention archive isnt long enough to fit a full minute- you may have points 10s-40s, or 20s-50s, etc. But the algorithm expects you to have points 0s-30s, and if not present at those exact offsets will consider them junk and not include them in the rollup, lowering your xff and potentially not aggregating at all.

In any case, I've preserved this behavior in our implementation and added a couple tests against python-generated and python-updated whisper files with varying schemas, aggregation types and xffs, and our results match byte-for-byte.